### PR TITLE
feat: Add assertion to Zane and Parser

### DIFF
--- a/src/main/java/zane/ui/Parser.java
+++ b/src/main/java/zane/ui/Parser.java
@@ -26,6 +26,7 @@ public class Parser {
     public static Command parse(String userInput) throws ZaneException {
         String[] inputParts = userInput.split(" ", 2);
         String commandWord = inputParts[0];
+        assert commandWord != null : "Command word cannot be null";
 
         switch (commandWord) {
         case "bye":

--- a/src/main/java/zane/ui/Zane.java
+++ b/src/main/java/zane/ui/Zane.java
@@ -37,6 +37,7 @@ public class Zane {
      * @return The response string from executing the command.
      */
     public String getResponse(String input) {
+        assert input != null : "User input cannot be null";
         try {
             Command command = Parser.parse(input);
             return command.execute(tasks, ui, storage);
@@ -55,6 +56,7 @@ public class Zane {
 
         while (!isExit) {
             String userInput = scanner.nextLine().trim();
+            assert userInput != null : "User input cannot be null";
             try {
                 Command command = Parser.parse(userInput);
                 String response = command.execute(tasks, ui, storage);


### PR DESCRIPTION
User input flows through Zane.getResponse(), Zane.run(), and Parser.parse(). These entry points do not check for null inputs.

Passing null due to a bug can cause a NullPointerException deep in the call stack, making debugging difficult.

Add assertions to fail fast when null is passed at these entry points.

Assertions are appropriate here since null indicates a programming error, not bad user data. They are off by default at runtime.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only adds `assert` checks on user-input entry points, which are typically disabled in production and do not alter normal command behavior unless assertions are enabled or null is passed.
> 
> **Overview**
> Adds fail-fast validation for programming errors by asserting non-null inputs at key entry points: `Zane.getResponse()`, the CLI loop in `Zane.run()`, and the parsed command word in `Parser.parse()`.
> 
> When assertions are enabled, passing `null` into these paths now fails immediately with clearer messages instead of causing later `NullPointerException`s.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b5996c544f19df390d95299dee32f66285381146. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->